### PR TITLE
fix the wrong translation of manual

### DIFF
--- a/zh_CN/koreader.po
+++ b/zh_CN/koreader.po
@@ -11930,7 +11930,7 @@ msgstr "自动"
 
 #: plugins/calibre.koplugin/main.lua:279
 msgid "Manual"
-msgstr "手册"
+msgstr "手动"
 
 #: plugins/calibre.koplugin/main.lua:293
 msgid "Set custom calibre address"


### PR DESCRIPTION
'manual' should be '手动 ' ,  not '手册'  , giving the context of  calibre server config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-translations/138)
<!-- Reviewable:end -->
