### PR TITLE
Adapt calendar words in french

### DIFF
--- a/fr/koreader.po
+++ b/fr/koreader.po
@@ -8126,51 +8126,51 @@ msgstr ""
 
 #: frontend/datetime.lua:15
 msgid "Jan"
-msgstr "Janv."
+msgstr "janv."
 
 #: frontend/datetime.lua:16
 msgid "Feb"
-msgstr "Févr."
+msgstr "févr."
 
 #: frontend/datetime.lua:17
 msgid "Mar"
-msgstr "Mars"
+msgstr "mars"
 
 #: frontend/datetime.lua:18
 msgid "Apr"
-msgstr "Avr."
+msgstr "avr."
 
 #: frontend/datetime.lua:19 frontend/datetime.lua:34
 msgid "May"
-msgstr "Mai"
+msgstr "mai"
 
 #: frontend/datetime.lua:20
 msgid "Jun"
-msgstr "Juin"
+msgstr "juin"
 
 #: frontend/datetime.lua:21
 msgid "Jul"
-msgstr "Juill."
+msgstr "juill."
 
 #: frontend/datetime.lua:22
 msgid "Aug"
-msgstr "Août"
+msgstr "août"
 
 #: frontend/datetime.lua:23
 msgid "Sep"
-msgstr "Sept."
+msgstr "sept."
 
 #: frontend/datetime.lua:24
 msgid "Oct"
-msgstr "Oct."
+msgstr "oct."
 
 #: frontend/datetime.lua:25
 msgid "Nov"
-msgstr "Nov."
+msgstr "nov."
 
 #: frontend/datetime.lua:26
 msgid "Dec"
-msgstr "Déc."
+msgstr "déc."
 
 #: frontend/datetime.lua:30
 msgid "January"

--- a/fr/koreader.po
+++ b/fr/koreader.po
@@ -8174,71 +8174,71 @@ msgstr "Déc."
 
 #: frontend/datetime.lua:30
 msgid "January"
-msgstr "Janvier"
+msgstr "janvier"
 
 #: frontend/datetime.lua:31
 msgid "February"
-msgstr "Février"
+msgstr "février"
 
 #: frontend/datetime.lua:32
 msgid "March"
-msgstr "Mars"
+msgstr "mars"
 
 #: frontend/datetime.lua:33
 msgid "April"
-msgstr "Avril"
+msgstr "avril"
 
 #: frontend/datetime.lua:35
 msgid "June"
-msgstr "Juin"
+msgstr "juin"
 
 #: frontend/datetime.lua:36
 msgid "July"
-msgstr "Juillet"
+msgstr "juillet"
 
 #: frontend/datetime.lua:37
 msgid "August"
-msgstr "Août"
+msgstr "août"
 
 #: frontend/datetime.lua:38
 msgid "September"
-msgstr "Septembre"
+msgstr "septembre"
 
 #: frontend/datetime.lua:39
 msgid "October"
-msgstr "Octobre"
+msgstr "octobre"
 
 #: frontend/datetime.lua:40
 msgid "November"
-msgstr "Novembre"
+msgstr "novembre"
 
 #: frontend/datetime.lua:41
 msgid "December"
-msgstr "Décembre"
+msgstr "décembre"
 
 #: frontend/datetime.lua:45
 msgid "Mon"
-msgstr "Lun"
+msgstr "lun"
 
 #: frontend/datetime.lua:46
 msgid "Tue"
-msgstr "Mar"
+msgstr "mar"
 
 #: frontend/datetime.lua:47
 msgid "Wed"
-msgstr "Mer"
+msgstr "mer"
 
 #: frontend/datetime.lua:48
 msgid "Thu"
-msgstr "Jeu"
+msgstr "jeu"
 
 #: frontend/datetime.lua:49
 msgid "Fri"
-msgstr "Ven"
+msgstr "ven"
 
 #: frontend/datetime.lua:50
 msgid "Sat"
-msgstr "Sam"
+msgstr "sam"
 
 #: frontend/datetime.lua:51
 msgid "Sun"
@@ -8246,31 +8246,31 @@ msgstr "Dim"
 
 #: frontend/datetime.lua:55
 msgid "Monday"
-msgstr "Lundi"
+msgstr "lundi"
 
 #: frontend/datetime.lua:56
 msgid "Tuesday"
-msgstr "Mardi"
+msgstr "mardi"
 
 #: frontend/datetime.lua:57
 msgid "Wednesday"
-msgstr "Mercredi"
+msgstr "mercredi"
 
 #: frontend/datetime.lua:58
 msgid "Thursday"
-msgstr "Jeudi"
+msgstr "jeudi"
 
 #: frontend/datetime.lua:59
 msgid "Friday"
-msgstr "Vendredi"
+msgstr "vendredi"
 
 #: frontend/datetime.lua:60
 msgid "Saturday"
-msgstr "Samedi"
+msgstr "samedi"
 
 #: frontend/datetime.lua:61
 msgid "Sunday"
-msgstr "Dimanche"
+msgstr "dimanche"
 
 #: frontend/datetime.lua:103 frontend/datetime.lua:106
 #: frontend/datetime.lua:181
@@ -8362,7 +8362,7 @@ msgstr "%-H:%M"
 #: frontend/datetime.lua:283
 msgctxt "Date string"
 msgid "%1 %2 %3 %4"
-msgstr "%1 %2 %3 %4"
+msgstr "%1 %3 %2 %4"
 
 #. @translators This is the date (%Y is the year, %m the month, %d the day)
 #: frontend/datetime.lua:287


### PR DESCRIPTION
Calendar words are not capitalized in french: https://www.lawlessfrench.com/grammar/capitalization/ (except if used at the begining of a sentence)

Order of calendar words when used in a sentence is day + number + month (+year) https://www.lawlessfrench.com/grammar/dates/

Reference for french abbreviations: https://fr.wikipedia.org/wiki/Mois#Abr%C3%A9viations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-translations/173)
<!-- Reviewable:end -->
